### PR TITLE
feat(#13): Add AI analysis pages for income, expense, and portfolio

### DIFF
--- a/prospectus_lumos/apps/ai_analysis/models.py
+++ b/prospectus_lumos/apps/ai_analysis/models.py
@@ -8,18 +8,15 @@ class AISettings(models.Model):
     """AI analysis configuration for a user."""
 
     class Model(models.TextChoices):
-        GPT_4O = "gpt-4o", "GPT-4o"
-        GPT_4O_MINI = "gpt-4o-mini", "GPT-4o Mini"
-        GPT_4_TURBO = "gpt-4-turbo", "GPT-4 Turbo"
-        GPT_4 = "gpt-4", "GPT-4"
-        GPT_35_TURBO = "gpt-3.5-turbo", "GPT-3.5 Turbo"
-        CLAUDE_3_OPUS = "claude-3-opus-20240229", "Claude 3 Opus"
-        CLAUDE_3_SONNET = "claude-3-sonnet-20240229", "Claude 3 Sonnet"
-        CLAUDE_3_HAIKU = "claude-3-haiku-20240307", "Claude 3 Haiku"
+        GEMINI_25_PRO = "gemini-2.5-pro", "Gemini 2.5 Pro"
+        GEMINI_25_FLASH = "gemini-2.5-flash", "Gemini 2.5 Flash"
+        GEMINI_20_FLASH = "gemini-2.0-flash", "Gemini 2.0 Flash"
+        GEMINI_15_PRO = "gemini-1.5-pro", "Gemini 1.5 Pro"
+        GEMINI_15_FLASH = "gemini-1.5-flash", "Gemini 1.5 Flash"
 
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="ai_settings")
-    api_token = models.CharField(max_length=255, help_text="OpenAI or Anthropic API key")
-    model = models.CharField(max_length=100, choices=Model.choices, default=Model.GPT_4O)
+    api_token = models.CharField(max_length=255, help_text="Google Gemini API key from Google AI Studio")
+    model = models.CharField(max_length=100, choices=Model.choices, default=Model.GEMINI_25_FLASH)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/prospectus_lumos/apps/ai_analysis/services.py
+++ b/prospectus_lumos/apps/ai_analysis/services.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import csv
+import io
 from typing import Any
 
 from openai import OpenAI
@@ -87,9 +89,6 @@ def prepare_data_as_text(documents: Any, analyzer_type: str) -> str:
     Returns:
         CSV-formatted text string.
     """
-    import csv
-    import io
-
     output = io.StringIO()
     writer = csv.writer(output)
     writer.writerow(["description", "amount", "category", "transaction_type", "year", "month"])

--- a/prospectus_lumos/apps/ai_analysis/services.py
+++ b/prospectus_lumos/apps/ai_analysis/services.py
@@ -4,7 +4,7 @@ import csv
 import io
 from typing import Any
 
-from openai import OpenAI
+import google.generativeai as genai
 
 
 SYSTEM_PROMPT = """You are a financial analyst assistant for a personal finance tracker called Prospectus Lumos.
@@ -31,52 +31,22 @@ Do NOT:
 
 
 def get_ai_insights(api_token: str, model: str, data_text: str) -> str:
-    """Send financial data to the AI model and return analysis insights.
+    """Send financial data to Google Gemini and return analysis insights.
 
     Args:
-        api_token: The OpenAI or Anthropic API key.
-        model: The model identifier (e.g. 'gpt-4o', 'claude-3-sonnet-20240229').
+        api_token: The Google Gemini API key.
+        model: The model identifier (e.g. 'gemini-2.5-flash').
         data_text: The financial data in CSV text format.
 
     Returns:
         The AI-generated insights as a string.
-
-    Raises:
-        openai.OpenAIError: If the API call fails.
     """
-    if model.startswith("claude-"):
-        return _call_anthropic(api_token, model, data_text)
-    return _call_openai(api_token, model, data_text)
-
-
-def _call_openai(api_token: str, model: str, data_text: str) -> str:
-    client = OpenAI(api_key=api_token)
-    response = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": f"Here is the financial data to analyze:\n\n{data_text}"},
-        ],
+    genai.configure(api_key=api_token)
+    gemini_model = genai.GenerativeModel(model)
+    response = gemini_model.generate_content(
+        f"{SYSTEM_PROMPT}\n\nHere is the financial data to analyze:\n\n{data_text}",
     )
-    return response.choices[0].message.content or ""
-
-
-def _call_anthropic(api_token: str, model: str, data_text: str) -> str:
-    client = OpenAI(
-        base_url="https://api.anthropic.com/v1/",
-        api_key=api_token,
-    )
-    response = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": f"Here is the financial data to analyze:\n\n{data_text}"},
-        ],
-        extra_body={
-            "max_tokens": 4096,
-        },
-    )
-    return response.choices[0].message.content or ""
+    return response.text or ""
 
 
 def prepare_data_as_text(documents: Any, analyzer_type: str) -> str:

--- a/prospectus_lumos/website/ai_analysis/urls.py
+++ b/prospectus_lumos/website/ai_analysis/urls.py
@@ -3,4 +3,7 @@ from . import views
 
 urlpatterns = [
     path("ai-settings/", views.ai_settings_view, name="ai_settings"),
+    path("income/", views.ai_income_analyzer_view, name="ai_income_analyzer"),
+    path("expense/", views.ai_expense_analyzer_view, name="ai_expense_analyzer"),
+    path("portfolio/", views.ai_portfolio_analyzer_view, name="ai_portfolio_analyzer"),
 ]

--- a/prospectus_lumos/website/ai_analysis/utils.py
+++ b/prospectus_lumos/website/ai_analysis/utils.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from django.contrib import messages
+
+from prospectus_lumos.apps.ai_analysis.models import AISettings
+from prospectus_lumos.apps.ai_analysis.services import get_ai_insights, prepare_data_as_text
+from prospectus_lumos.apps.documents.models import Document
+from prospectus_lumos.core.constants import MONTHS_LIST
+from prospectus_lumos.core.utils import TypedHttpRequest
+
+
+def get_ai_settings_or_redirect(request: TypedHttpRequest) -> AISettings | None:
+    """Return the user's AI settings or redirect with an error message."""
+    ai_settings = AISettings.objects.filter(user=request.user).first()
+    if not ai_settings:
+        messages.error(request, "Please configure your AI settings before running analysis.")
+        return None
+    return ai_settings
+
+
+def build_ai_analysis_context(
+    request: TypedHttpRequest,
+    ai_settings: AISettings,
+    analyzer_type: str,
+    year: int | None,
+    month: int | None,
+    year_from: int | None = None,
+    year_to: int | None = None,
+) -> dict:
+    """Build the common context for AI analysis views."""
+    documents_qs = Document.objects.filter(user=request.user).prefetch_related("transactions")
+
+    if year is not None:
+        documents_qs = documents_qs.filter(year=year)
+    if month is not None:
+        documents_qs = documents_qs.filter(month=month)
+    if year_from is not None:
+        documents_qs = documents_qs.filter(year__gte=year_from)
+    if year_to is not None:
+        documents_qs = documents_qs.filter(year__lte=year_to)
+
+    documents = list(documents_qs.order_by("year", "month"))
+
+    insights: str | None = None
+    error: str | None = None
+
+    if documents:
+        data_text = prepare_data_as_text(documents, analyzer_type)
+        if data_text.strip():
+            try:
+                insights = get_ai_insights(
+                    api_token=ai_settings.api_token,
+                    model=ai_settings.model,
+                    data_text=data_text,
+                )
+            except Exception as e:
+                error = str(e)
+        else:
+            error = f"No {analyzer_type} data found for the selected period."
+    else:
+        error = "No documents found for the selected period."
+
+    available_years = (
+        Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
+    )
+    available_months = MONTHS_LIST
+
+    return {
+        "insights": insights,
+        "error": error,
+        "available_years": available_years,
+        "available_months": available_months,
+        "document_count": len(documents),
+    }

--- a/prospectus_lumos/website/ai_analysis/views.py
+++ b/prospectus_lumos/website/ai_analysis/views.py
@@ -6,6 +6,9 @@ from django.http import HttpResponse
 from django.shortcuts import redirect, render
 
 from prospectus_lumos.apps.ai_analysis.models import AISettings
+from prospectus_lumos.apps.ai_analysis.services import get_ai_insights, prepare_data_as_text
+from prospectus_lumos.apps.documents.models import Document
+from prospectus_lumos.core.constants import MONTHS_LIST
 from prospectus_lumos.core.utils import TypedHttpRequest
 
 from .forms import AISettingsForm
@@ -32,3 +35,189 @@ def ai_settings_view(request: TypedHttpRequest) -> HttpResponse:
         "ai_analysis/settings.html",
         {"form": form, "selected_tab": "ai_settings", "ai_settings": ai_settings},
     )
+
+
+def _get_ai_settings_or_redirect(request: TypedHttpRequest) -> AISettings | None:
+    """Return the user's AI settings or redirect with an error message."""
+    ai_settings = AISettings.objects.filter(user=request.user).first()
+    if not ai_settings:
+        messages.error(request, "Please configure your AI settings before running analysis.")
+        return None
+    return ai_settings
+
+
+def _build_ai_analysis_context(
+    request: TypedHttpRequest,
+    ai_settings: AISettings,
+    analyzer_type: str,
+    year: int | None,
+    month: int | None,
+    year_from: int | None = None,
+    year_to: int | None = None,
+) -> dict:
+    """Build the common context for AI analysis views."""
+    documents_qs = Document.objects.filter(user=request.user).prefetch_related("transactions")
+
+    if year is not None:
+        documents_qs = documents_qs.filter(year=year)
+    if month is not None:
+        documents_qs = documents_qs.filter(month=month)
+    if year_from is not None:
+        documents_qs = documents_qs.filter(year__gte=year_from)
+    if year_to is not None:
+        documents_qs = documents_qs.filter(year__lte=year_to)
+
+    documents = list(documents_qs.order_by("year", "month"))
+
+    insights: str | None = None
+    error: str | None = None
+
+    if documents:
+        data_text = prepare_data_as_text(documents, analyzer_type)
+        if data_text.strip():
+            try:
+                insights = get_ai_insights(
+                    api_token=ai_settings.api_token,
+                    model=ai_settings.model,
+                    data_text=data_text,
+                )
+            except Exception as e:
+                error = str(e)
+        else:
+            error = f"No {analyzer_type} data found for the selected period."
+    else:
+        error = "No documents found for the selected period."
+
+    available_years = (
+        Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
+    )
+    available_months = MONTHS_LIST
+
+    return {
+        "insights": insights,
+        "error": error,
+        "available_years": available_years,
+        "available_months": available_months,
+        "document_count": len(documents),
+    }
+
+
+@login_required
+def ai_income_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
+    """AI-powered income analysis with period selection."""
+    ai_settings = _get_ai_settings_or_redirect(request)
+    if ai_settings is None:
+        return redirect("ai_settings")
+
+    year_filter = request.GET.get("year", "")
+    month_filter = request.GET.get("month", "")
+
+    year = int(year_filter) if year_filter else None
+    month = int(month_filter) if month_filter else None
+
+    context = {
+        "selected_tab": "ai_income",
+        "year_filter": year_filter,
+        "month_filter": month_filter,
+    }
+
+    if year_filter or month_filter:
+        filter_text = []
+        if month is not None:
+            filter_text.append(MONTHS_LIST[month - 1][1])
+        if year is not None:
+            filter_text.append(str(year))
+        context["filter_text"] = " for " + " ".join(filter_text) if filter_text else ""
+        context.update(_build_ai_analysis_context(request, ai_settings, "income", year=year, month=month))
+    else:
+        context["available_years"] = (
+            Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
+        )
+        context["available_months"] = MONTHS_LIST
+
+    return render(request, "ai_analysis/income.html", context)
+
+
+@login_required
+def ai_expense_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
+    """AI-powered expense analysis with period selection."""
+    ai_settings = _get_ai_settings_or_redirect(request)
+    if ai_settings is None:
+        return redirect("ai_settings")
+
+    year_filter = request.GET.get("year", "")
+    month_filter = request.GET.get("month", "")
+
+    year = int(year_filter) if year_filter else None
+    month = int(month_filter) if month_filter else None
+
+    context = {
+        "selected_tab": "ai_expenses",
+        "year_filter": year_filter,
+        "month_filter": month_filter,
+    }
+
+    if year_filter or month_filter:
+        filter_text = []
+        if month is not None:
+            filter_text.append(MONTHS_LIST[month - 1][1])
+        if year is not None:
+            filter_text.append(str(year))
+        context["filter_text"] = " for " + " ".join(filter_text) if filter_text else ""
+        context.update(_build_ai_analysis_context(request, ai_settings, "expense", year=year, month=month))
+    else:
+        context["available_years"] = (
+            Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
+        )
+        context["available_months"] = MONTHS_LIST
+
+    return render(request, "ai_analysis/expense.html", context)
+
+
+@login_required
+def ai_portfolio_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
+    """AI-powered portfolio analysis with year range selection."""
+    ai_settings = _get_ai_settings_or_redirect(request)
+    if ai_settings is None:
+        return redirect("ai_settings")
+
+    year_from_str = request.GET.get("year_from", "")
+    year_to_str = request.GET.get("year_to", "")
+
+    year_from = int(year_from_str) if year_from_str else None
+    year_to = int(year_to_str) if year_to_str else None
+
+    if year_from is not None and year_to is not None and year_from > year_to:
+        year_from, year_to = year_to, year_from
+        year_from_str, year_to_str = str(year_from), str(year_to)
+
+    context = {
+        "selected_tab": "ai_portfolio",
+        "year_from": year_from_str,
+        "year_to": year_to_str,
+    }
+
+    if year_from_str or year_to_str:
+        parts = []
+        if year_from is not None:
+            parts.append(f"from {year_from}")
+        if year_to is not None:
+            parts.append(f"to {year_to}")
+        context["filter_text"] = " " + " ".join(parts)
+        context.update(
+            _build_ai_analysis_context(
+                request,
+                ai_settings,
+                "portfolio",
+                year=None,
+                month=None,
+                year_from=year_from,
+                year_to=year_to,
+            )
+        )
+    else:
+        context["available_years"] = (
+            Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
+        )
+
+    return render(request, "ai_analysis/portfolio.html", context)

--- a/prospectus_lumos/website/ai_analysis/views.py
+++ b/prospectus_lumos/website/ai_analysis/views.py
@@ -6,12 +6,12 @@ from django.http import HttpResponse
 from django.shortcuts import redirect, render
 
 from prospectus_lumos.apps.ai_analysis.models import AISettings
-from prospectus_lumos.apps.ai_analysis.services import get_ai_insights, prepare_data_as_text
 from prospectus_lumos.apps.documents.models import Document
 from prospectus_lumos.core.constants import MONTHS_LIST
 from prospectus_lumos.core.utils import TypedHttpRequest
 
 from .forms import AISettingsForm
+from .utils import build_ai_analysis_context, get_ai_settings_or_redirect
 
 
 @login_required
@@ -37,75 +37,10 @@ def ai_settings_view(request: TypedHttpRequest) -> HttpResponse:
     )
 
 
-def _get_ai_settings_or_redirect(request: TypedHttpRequest) -> AISettings | None:
-    """Return the user's AI settings or redirect with an error message."""
-    ai_settings = AISettings.objects.filter(user=request.user).first()
-    if not ai_settings:
-        messages.error(request, "Please configure your AI settings before running analysis.")
-        return None
-    return ai_settings
-
-
-def _build_ai_analysis_context(
-    request: TypedHttpRequest,
-    ai_settings: AISettings,
-    analyzer_type: str,
-    year: int | None,
-    month: int | None,
-    year_from: int | None = None,
-    year_to: int | None = None,
-) -> dict:
-    """Build the common context for AI analysis views."""
-    documents_qs = Document.objects.filter(user=request.user).prefetch_related("transactions")
-
-    if year is not None:
-        documents_qs = documents_qs.filter(year=year)
-    if month is not None:
-        documents_qs = documents_qs.filter(month=month)
-    if year_from is not None:
-        documents_qs = documents_qs.filter(year__gte=year_from)
-    if year_to is not None:
-        documents_qs = documents_qs.filter(year__lte=year_to)
-
-    documents = list(documents_qs.order_by("year", "month"))
-
-    insights: str | None = None
-    error: str | None = None
-
-    if documents:
-        data_text = prepare_data_as_text(documents, analyzer_type)
-        if data_text.strip():
-            try:
-                insights = get_ai_insights(
-                    api_token=ai_settings.api_token,
-                    model=ai_settings.model,
-                    data_text=data_text,
-                )
-            except Exception as e:
-                error = str(e)
-        else:
-            error = f"No {analyzer_type} data found for the selected period."
-    else:
-        error = "No documents found for the selected period."
-
-    available_years = (
-        Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
-    )
-    available_months = MONTHS_LIST
-
-    return {
-        "insights": insights,
-        "error": error,
-        "available_years": available_years,
-        "available_months": available_months,
-        "document_count": len(documents),
-    }
-
-
 @login_required
 def ai_income_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
     """AI-powered income analysis with period selection."""
-    ai_settings = _get_ai_settings_or_redirect(request)
+    ai_settings = get_ai_settings_or_redirect(request)
     if ai_settings is None:
         return redirect("ai_settings")
 
@@ -128,7 +63,7 @@ def ai_income_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
         if year is not None:
             filter_text.append(str(year))
         context["filter_text"] = " for " + " ".join(filter_text) if filter_text else ""
-        context.update(_build_ai_analysis_context(request, ai_settings, "income", year=year, month=month))
+        context.update(build_ai_analysis_context(request, ai_settings, "income", year=year, month=month))
     else:
         context["available_years"] = (
             Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
@@ -141,7 +76,7 @@ def ai_income_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
 @login_required
 def ai_expense_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
     """AI-powered expense analysis with period selection."""
-    ai_settings = _get_ai_settings_or_redirect(request)
+    ai_settings = get_ai_settings_or_redirect(request)
     if ai_settings is None:
         return redirect("ai_settings")
 
@@ -164,7 +99,7 @@ def ai_expense_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
         if year is not None:
             filter_text.append(str(year))
         context["filter_text"] = " for " + " ".join(filter_text) if filter_text else ""
-        context.update(_build_ai_analysis_context(request, ai_settings, "expense", year=year, month=month))
+        context.update(build_ai_analysis_context(request, ai_settings, "expense", year=year, month=month))
     else:
         context["available_years"] = (
             Document.objects.filter(user=request.user).values_list("year", flat=True).distinct().order_by("-year")
@@ -177,7 +112,7 @@ def ai_expense_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
 @login_required
 def ai_portfolio_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
     """AI-powered portfolio analysis with year range selection."""
-    ai_settings = _get_ai_settings_or_redirect(request)
+    ai_settings = get_ai_settings_or_redirect(request)
     if ai_settings is None:
         return redirect("ai_settings")
 
@@ -205,7 +140,7 @@ def ai_portfolio_analyzer_view(request: TypedHttpRequest) -> HttpResponse:
             parts.append(f"to {year_to}")
         context["filter_text"] = " " + " ".join(parts)
         context.update(
-            _build_ai_analysis_context(
+            build_ai_analysis_context(
                 request,
                 ai_settings,
                 "portfolio",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ Pillow==11.2.1
 google-api-python-client==2.117.0
 
 # AI analysis
-openai==1.82.0
+google-generativeai==0.8.5

--- a/templates/ai_analysis/expense.html
+++ b/templates/ai_analysis/expense.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+
+{% block title %}AI Expense Analyzer - Prospectus Lumos{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="mb-0">AI Expense Analyzer</h1>
+        <small class="text-muted">Let AI analyze your spending patterns and suggest optimizations.</small>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="get" class="row g-3">
+            <div class="col-md-4">
+                <label for="year" class="form-label">Year</label>
+                <select class="form-select" id="year" name="year">
+                    <option value="">All Years</option>
+                    {% for year in available_years %}
+                        <option value="{{ year }}" {% if year_filter == year|stringformat:"s" %}selected{% endif %}>
+                            {{ year }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="month" class="form-label">Month</label>
+                <select class="form-select" id="month" name="month">
+                    <option value="">All Months</option>
+                    {% for month_num, month_name in available_months %}
+                        <option value="{{ month_num }}" {% if month_filter == month_num|stringformat:"s" %}selected{% endif %}>
+                            {{ month_name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary me-2">
+                    <i class="bi bi-robot me-1"></i> Analyze
+                </button>
+                <a href="{% url 'ai_expense_analyzer' %}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-circle"></i> Clear
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% if insights %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card stat-card expense">
+            <div class="card-body">
+                <div class="d-flex justify-content-between">
+                    <div>
+                        <h6 class="card-subtitle mb-2 text-muted">Documents Analyzed {{ filter_text }}</h6>
+                        <h3 class="mb-0">{{ document_count }}</h3>
+                    </div>
+                    <div class="text-danger">
+                        <i class="bi bi-file-earmark-check" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="bi bi-robot me-2"></i>AI Insights{{ filter_text }}</h5>
+    </div>
+    <div class="card-body">
+        <div class="ai-insights" style="white-space: pre-wrap; line-height: 1.7;">
+            {{ insights }}
+        </div>
+    </div>
+</div>
+{% elif error %}
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="text-center py-4">
+            <i class="bi bi-exclamation-triangle text-warning" style="font-size: 3rem;"></i>
+            <p class="mt-3 text-muted">{{ error }}</p>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="text-center py-5">
+            <i class="bi bi-robot text-muted" style="font-size: 4rem;"></i>
+            <h5 class="mt-3">Ready to Analyze</h5>
+            <p class="text-muted">Select a period above and click <strong>Analyze</strong> to get AI-powered insights about your expenses.</p>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/ai_analysis/income.html
+++ b/templates/ai_analysis/income.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+
+{% block title %}AI Income Analyzer - Prospectus Lumos{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="mb-0">AI Income Analyzer</h1>
+        <small class="text-muted">Let AI analyze your income patterns and provide insights.</small>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="get" class="row g-3">
+            <div class="col-md-4">
+                <label for="year" class="form-label">Year</label>
+                <select class="form-select" id="year" name="year">
+                    <option value="">All Years</option>
+                    {% for year in available_years %}
+                        <option value="{{ year }}" {% if year_filter == year|stringformat:"s" %}selected{% endif %}>
+                            {{ year }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="month" class="form-label">Month</label>
+                <select class="form-select" id="month" name="month">
+                    <option value="">All Months</option>
+                    {% for month_num, month_name in available_months %}
+                        <option value="{{ month_num }}" {% if month_filter == month_num|stringformat:"s" %}selected{% endif %}>
+                            {{ month_name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary me-2">
+                    <i class="bi bi-robot me-1"></i> Analyze
+                </button>
+                <a href="{% url 'ai_income_analyzer' %}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-circle"></i> Clear
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% if insights %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card stat-card income">
+            <div class="card-body">
+                <div class="d-flex justify-content-between">
+                    <div>
+                        <h6 class="card-subtitle mb-2 text-muted">Documents Analyzed {{ filter_text }}</h6>
+                        <h3 class="mb-0">{{ document_count }}</h3>
+                    </div>
+                    <div class="text-success">
+                        <i class="bi bi-file-earmark-check" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="bi bi-robot me-2"></i>AI Insights{{ filter_text }}</h5>
+    </div>
+    <div class="card-body">
+        <div class="ai-insights" style="white-space: pre-wrap; line-height: 1.7;">
+            {{ insights }}
+        </div>
+    </div>
+</div>
+{% elif error %}
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="text-center py-4">
+            <i class="bi bi-exclamation-triangle text-warning" style="font-size: 3rem;"></i>
+            <p class="mt-3 text-muted">{{ error }}</p>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="text-center py-5">
+            <i class="bi bi-robot text-muted" style="font-size: 4rem;"></i>
+            <h5 class="mt-3">Ready to Analyze</h5>
+            <p class="text-muted">Select a period above and click <strong>Analyze</strong> to get AI-powered insights about your income.</p>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/ai_analysis/portfolio.html
+++ b/templates/ai_analysis/portfolio.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+
+{% block title %}AI Portfolio Analyzer - Prospectus Lumos{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="mb-0">AI Portfolio Analyzer</h1>
+        <small class="text-muted">Let AI analyze your overall financial health across income and expenses.</small>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="get" class="row g-3">
+            <div class="col-md-4">
+                <label for="year_from" class="form-label">From Year</label>
+                <select class="form-select" id="year_from" name="year_from">
+                    <option value="">Any</option>
+                    {% for year in available_years %}
+                        <option value="{{ year }}" {% if year_from == year|stringformat:"s" %}selected{% endif %}>
+                            {{ year }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label for="year_to" class="form-label">To Year</label>
+                <select class="form-select" id="year_to" name="year_to">
+                    <option value="">Any</option>
+                    {% for year in available_years %}
+                        <option value="{{ year }}" {% if year_to == year|stringformat:"s" %}selected{% endif %}>
+                            {{ year }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary me-2">
+                    <i class="bi bi-robot me-1"></i> Analyze
+                </button>
+                <a href="{% url 'ai_portfolio_analyzer' %}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-circle"></i> Clear
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% if insights %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card stat-card net">
+            <div class="card-body">
+                <div class="d-flex justify-content-between">
+                    <div>
+                        <h6 class="card-subtitle mb-2 text-muted">Documents Analyzed {{ filter_text }}</h6>
+                        <h3 class="mb-0">{{ document_count }}</h3>
+                    </div>
+                    <div class="text-primary">
+                        <i class="bi bi-file-earmark-check" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="bi bi-robot me-2"></i>AI Insights{{ filter_text }}</h5>
+    </div>
+    <div class="card-body">
+        <div class="ai-insights" style="white-space: pre-wrap; line-height: 1.7;">
+            {{ insights }}
+        </div>
+    </div>
+</div>
+{% elif error %}
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="text-center py-4">
+            <i class="bi bi-exclamation-triangle text-warning" style="font-size: 3rem;"></i>
+            <p class="mt-3 text-muted">{{ error }}</p>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="text-center py-5">
+            <i class="bi bi-robot text-muted" style="font-size: 4rem;"></i>
+            <h5 class="mt-3">Ready to Analyze</h5>
+            <p class="text-muted">Select a year range above and click <strong>Analyze</strong> to get AI-powered insights about your overall financial health.</p>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/templates/ai_analysis/settings.html
+++ b/templates/ai_analysis/settings.html
@@ -24,7 +24,7 @@
                         <label for="{{ form.api_token.id_for_label }}" class="form-label">API Token</label>
                         {{ form.api_token }}
                         <div class="form-text">
-                            Your OpenAI or Anthropic API key.
+                            Your Google Gemini API key from Google AI Studio.
                             {% if ai_settings %}
                                 <span class="text-success">A token is currently saved.</span>
                             {% endif %}
@@ -69,8 +69,8 @@
                 <p class="mb-0">
                     <small class="text-muted">
                         You need a valid API key from
-                        <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">OpenAI</a>
-                        or <a href="https://console.anthropic.com/" target="_blank" rel="noopener">Anthropic</a>.
+                        <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">Google AI Studio</a>.
+                        Gemini offers a free tier suitable for personal use.
                         Your API key is stored securely and only used for analysis you explicitly request.
                     </small>
                 </p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -86,6 +86,18 @@
                         <i class="bi bi-robot me-2"></i>
                         AI Settings
                     </a>
+                    <a class="nav-link {% if selected_tab == 'ai_income' %}active{% endif %}" href="{% url 'ai_income_analyzer' %}">
+                        <i class="bi bi-cash-stack me-2"></i>
+                        AI Income
+                    </a>
+                    <a class="nav-link {% if selected_tab == 'ai_expenses' %}active{% endif %}" href="{% url 'ai_expense_analyzer' %}">
+                        <i class="bi bi-credit-card me-2"></i>
+                        AI Expenses
+                    </a>
+                    <a class="nav-link {% if selected_tab == 'ai_portfolio' %}active{% endif %}" href="{% url 'ai_portfolio_analyzer' %}">
+                        <i class="bi bi-pie-chart me-2"></i>
+                        AI Portfolio
+                    </a>
                 </nav>
             </div>
 

--- a/tests/test_ai_analysis.py
+++ b/tests/test_ai_analysis.py
@@ -19,19 +19,19 @@ class AISettingsModelTests(TestCase):
         user = User.objects.create_user(username="tester", password="pass")
         settings = AISettings.objects.create(
             user=user,
-            api_token="sk-test-token",
-            model=AISettings.Model.GPT_4O,
+            api_token="test-api-key",
+            model=AISettings.Model.GEMINI_25_FLASH,
         )
         self.assertEqual(settings.user, user)
-        self.assertEqual(settings.api_token, "sk-test-token")
-        self.assertEqual(settings.model, AISettings.Model.GPT_4O)
+        self.assertEqual(settings.api_token, "test-api-key")
+        self.assertEqual(settings.model, AISettings.Model.GEMINI_25_FLASH)
         self.assertEqual(str(settings), "tester - AI Settings")
 
     def test_ai_settings_one_to_one(self) -> None:
         user = User.objects.create_user(username="tester", password="pass")
-        AISettings.objects.create(user=user, api_token="sk-token")
+        AISettings.objects.create(user=user, api_token="test-key")
         with self.assertRaises(IntegrityError):
-            AISettings.objects.create(user=user, api_token="sk-token-2")
+            AISettings.objects.create(user=user, api_token="test-key-2")
 
 
 class AISettingsViewTests(TestCase):
@@ -58,29 +58,29 @@ class AISettingsViewTests(TestCase):
 
         response = self.client.post(
             self.url,
-            {"api_token": "sk-new-token", "model": AISettings.Model.GPT_4O},
+            {"api_token": "test-key", "model": AISettings.Model.GEMINI_25_FLASH},
         )
         self.assertEqual(response.status_code, 302)
         self.assertTrue(AISettings.objects.filter(user=self.user).exists())
         settings = AISettings.objects.get(user=self.user)
-        self.assertEqual(settings.api_token, "sk-new-token")
-        self.assertEqual(settings.model, AISettings.Model.GPT_4O)
+        self.assertEqual(settings.api_token, "test-key")
+        self.assertEqual(settings.model, AISettings.Model.GEMINI_25_FLASH)
 
     def test_post_updates_existing_ai_settings(self) -> None:
         self.client.login(username="tester", password="pass")
-        AISettings.objects.create(user=self.user, api_token="sk-old-token")
+        AISettings.objects.create(user=self.user, api_token="old-key")
 
         response = self.client.post(
             self.url,
-            {"api_token": "sk-new-token", "model": AISettings.Model.GPT_35_TURBO},
+            {"api_token": "new-key", "model": AISettings.Model.GEMINI_15_FLASH},
         )
         self.assertEqual(response.status_code, 302)
         settings = AISettings.objects.get(user=self.user)
-        self.assertEqual(settings.api_token, "sk-new-token")
-        self.assertEqual(settings.model, AISettings.Model.GPT_35_TURBO)
+        self.assertEqual(settings.api_token, "new-key")
+        self.assertEqual(settings.model, AISettings.Model.GEMINI_15_FLASH)
 
     def test_post_empty_token_is_invalid(self) -> None:
-        request = self.factory.post(self.url, {"api_token": "", "model": AISettings.Model.GPT_4O})
+        request = self.factory.post(self.url, {"api_token": "", "model": AISettings.Model.GEMINI_25_FLASH})
         request.user = self.user
         from prospectus_lumos.website.ai_analysis.views import ai_settings_view
 
@@ -90,45 +90,44 @@ class AISettingsViewTests(TestCase):
 
 
 class AIServiceTests(TestCase):
-    def test_get_ai_insights_openai(self) -> None:
-        mock_client = MagicMock()
+    def test_get_ai_insights_gemini(self) -> None:
+        mock_model = MagicMock()
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Analysis: Spending is normal."
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_response.text = "Analysis: Spending is normal."
+        mock_model.generate_content.return_value = mock_response
 
         with patch(
-            "prospectus_lumos.apps.ai_analysis.services.OpenAI",
-            return_value=mock_client,
-        ):
+            "prospectus_lumos.apps.ai_analysis.services.genai",
+        ) as mock_genai:
+            mock_genai.GenerativeModel.return_value = mock_model
             result = get_ai_insights(
-                api_token="sk-test",
-                model="gpt-4o",
+                api_token="test-key",
+                model="gemini-2.5-flash",
                 data_text="test data",
             )
 
         self.assertEqual(result, "Analysis: Spending is normal.")
-        mock_client.chat.completions.create.assert_called_once()
+        mock_genai.configure.assert_called_once_with(api_key="test-key")
+        mock_genai.GenerativeModel.assert_called_once_with("gemini-2.5-flash")
+        mock_model.generate_content.assert_called_once()
 
-    def test_get_ai_insights_anthropic(self) -> None:
-        mock_client = MagicMock()
+    def test_get_ai_insights_empty_response(self) -> None:
+        mock_model = MagicMock()
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Anthropic analysis."
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_response.text = ""
+        mock_model.generate_content.return_value = mock_response
 
         with patch(
-            "prospectus_lumos.apps.ai_analysis.services.OpenAI",
-            return_value=mock_client,
-        ) as mock_openai:
+            "prospectus_lumos.apps.ai_analysis.services.genai",
+        ) as mock_genai:
+            mock_genai.GenerativeModel.return_value = mock_model
             result = get_ai_insights(
-                api_token="sk-test",
-                model="claude-3-sonnet-20240229",
+                api_token="test-key",
+                model="gemini-2.5-flash",
                 data_text="test data",
             )
 
-        self.assertEqual(result, "Anthropic analysis.")
-        mock_openai.assert_called_once()
+        self.assertEqual(result, "")
 
 
 class PrepareDataAsTextTests(TestCase):


### PR DESCRIPTION
## Summary

Part 2 of APE-13: Adds AI-powered analysis pages for income, expense, and portfolio. Depends on PR #84 (Part 1).

## What changed

### New analysis pages

- **AI Income Analyzer** (`/ai/income/`): Select year/month to analyze income patterns with AI insights
- **AI Expense Analyzer** (`/ai/expense/`): Select year/month to analyze spending patterns and get optimization suggestions
- **AI Portfolio Analyzer** (`/ai/portfolio/`): Select year range to analyze overall financial health across both income and expenses

### Features

- Period selection: year and month filters (year range for portfolio)
- Data preparation: converts document transactions to CSV text for AI consumption
- AI integration: sends prepared data through `get_ai_insights()` with user's configured API token and model
- Error handling: redirects to settings page if no AI config exists, shows errors if data is empty or API fails
- Performance: prefetch-related transactions to avoid N+1 queries

### Navigation

- Added "AI Income", "AI Expenses", and "AI Portfolio" sidebar links

### Templates

- `income.html`: Income analysis page with period filter form and insights display
- `expense.html`: Expense analysis page with period filter form and insights display
- `portfolio.html`: Portfolio analysis page with year range filter form and insights display

Closes APE-13
