### PR TITLE
feat: Add centralized loading indicator for slow-loading pages

### DIFF
--- a/static_files/css/theme.css
+++ b/static_files/css/theme.css
@@ -206,3 +206,43 @@ body {
 .text-muted {
   color: var(--muted-text) !important;
 }
+
+/* Loading indicator overlay */
+.loading-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  background: rgba(255, 255, 255, 0.85);
+  justify-content: center;
+  align-items: center;
+}
+
+.loading-overlay.is-active {
+  display: flex;
+}
+
+.loading-overlay__content {
+  text-align: center;
+  padding: var(--space-8, 2rem);
+}
+
+.loading-overlay .spinner-border {
+  width: 3rem;
+  height: 3rem;
+  color: var(--primary-color);
+}
+
+.loading-overlay__text {
+  font-size: 1rem;
+  color: var(--text-color);
+  font-weight: 500;
+}
+
+.dark .loading-overlay {
+  background: rgba(11, 18, 32, 0.85);
+}
+
+.dark .loading-overlay__text {
+  color: var(--text-color);
+}

--- a/static_files/js/loading-indicator.js
+++ b/static_files/js/loading-indicator.js
@@ -1,0 +1,25 @@
+(function() {
+  var overlay = document.getElementById('loading-overlay');
+  var loadingText = document.getElementById('loading-text');
+  if (!overlay) return;
+
+  function showLoading(text) {
+    if (loadingText) {
+      loadingText.textContent = text || 'Loading...';
+    }
+    overlay.setAttribute('aria-hidden', 'false');
+    overlay.classList.add('is-active');
+  }
+
+  document.addEventListener('submit', function(e) {
+    var form = e.target;
+    if (!form.dataset.loading) return;
+    showLoading(form.dataset.loadingText || null);
+  });
+
+  document.querySelectorAll('a[data-loading]').forEach(function(link) {
+    link.addEventListener('click', function(e) {
+      showLoading(link.dataset.loadingText || null);
+    });
+  });
+})();

--- a/templates/ai_analysis/expense.html
+++ b/templates/ai_analysis/expense.html
@@ -12,7 +12,7 @@
 
 <div class="card mb-4">
     <div class="card-body">
-        <form method="get" class="row g-3">
+        <form method="get" class="row g-3" data-loading data-loading-text="Generating AI insights for expenses...">
             <div class="col-md-4">
                 <label for="year" class="form-label">Year</label>
                 <select class="form-select" id="year" name="year">

--- a/templates/ai_analysis/income.html
+++ b/templates/ai_analysis/income.html
@@ -12,7 +12,7 @@
 
 <div class="card mb-4">
     <div class="card-body">
-        <form method="get" class="row g-3">
+        <form method="get" class="row g-3" data-loading data-loading-text="Generating AI insights for income...">
             <div class="col-md-4">
                 <label for="year" class="form-label">Year</label>
                 <select class="form-select" id="year" name="year">

--- a/templates/ai_analysis/portfolio.html
+++ b/templates/ai_analysis/portfolio.html
@@ -12,7 +12,7 @@
 
 <div class="card mb-4">
     <div class="card-body">
-        <form method="get" class="row g-3">
+        <form method="get" class="row g-3" data-loading data-loading-text="Generating AI insights for portfolio...">
             <div class="col-md-4">
                 <label for="year_from" class="form-label">From Year</label>
                 <select class="form-select" id="year_from" name="year_from">

--- a/templates/base.html
+++ b/templates/base.html
@@ -131,8 +131,12 @@
         </div>
     </footer>
 
+    {% include "partials/loading_indicator.html" %}
+
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+    <script src="{% static 'js/loading-indicator.js' %}"></script>
 
     {% block extra_js %}{% endblock %}
     <script>

--- a/templates/expenses/dashboard.html
+++ b/templates/expenses/dashboard.html
@@ -13,7 +13,7 @@
     </div>
 
     {% if document_sources %}
-    <form method="post" action="{% url 'sync_documents' %}">
+    <form method="post" action="{% url 'sync_documents' %}" data-loading data-loading-text="Syncing documents from Google Drive...">
         {% csrf_token %}
         <button type="submit" class="btn btn-primary">
             <i class="bi bi-arrow-clockwise me-2"></i>

--- a/templates/expenses/document_list.html
+++ b/templates/expenses/document_list.html
@@ -111,7 +111,7 @@
                                 <small class="text-muted">{{ doc.processed_at|date:"M d, Y" }}</small>
                             </td>
                             <td class="text-end">
-                                <form method="post" action="{% url 'resync_document' doc.id %}" class="d-inline">
+                                <form method="post" action="{% url 'resync_document' doc.id %}" class="d-inline" data-loading data-loading-text="Resyncing document from Google Sheets...">
                                     {% csrf_token %}
                                     <button class="btn btn-sm btn-outline-secondary" title="Resync" {% if not doc.google_sheet_id %}disabled{% endif %}>
                                         <i class="bi bi-arrow-repeat"></i>

--- a/templates/partials/loading_indicator.html
+++ b/templates/partials/loading_indicator.html
@@ -1,0 +1,8 @@
+<div id="loading-overlay" class="loading-overlay" aria-hidden="true">
+    <div class="loading-overlay__content">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+        <p class="loading-overlay__text mt-3 mb-0" id="loading-text">Loading...</p>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Add a centralized, reusable loading indicator component and apply it to every page that may have long load times (document syncing, AI insights generation), so users see active feedback while waiting instead of an apparently unresponsive page.

## Changes

- **templates/partials/loading_indicator.html** — A Bootstrap spinner overlay partial included in the base template. Controlled via CSS class toggle.
- **static_files/js/loading-indicator.js** — Centralized JS that intercepts form submissions with `data-loading` attributes, shows the overlay, and customizes the loading text via `data-loading-text`.
- **static_files/css/theme.css** — Fixed overlay styling with dark mode support.

## Pages updated

| Page | Operation | Indicator text |
|------|-----------|----------------|
| Dashboard | Sync Documents | "Syncing documents from Google Drive..." |
| Document List | Resync document | "Resyncing document from Google Sheets..." |
| AI Income Analyzer | Analyze | "Generating AI insights for income..." |
| AI Expense Analyzer | Analyze | "Generating AI insights for expenses..." |
| AI Portfolio Analyzer | Analyze | "Generating AI insights for portfolio..." |

## Usage

Any form that triggers a slow operation just needs `data-loading` and `data-loading-text` attributes — the centralized JS handles the rest. No per-page re-implementations needed.

## Checklist

- [x] A reusable, centralized loading indicator component is implemented
- [x] Loading indicator is shown while document syncing is in progress
- [x] Loading indicator is shown while AI insights are generating
- [x] Pages without slow operations render normally with no erroneous loading state
- [x] Existing page behavior and layouts are preserved

---

Closes APE-14