### PR TITLE
feat: Translate AI insights to English, restyle AI page, and add analyzer navigation buttons

### DIFF
--- a/prospectus_lumos/apps/ai_analysis/services.py
+++ b/prospectus_lumos/apps/ai_analysis/services.py
@@ -21,7 +21,8 @@ You MUST:
 - Provide actionable, truthful insights — never make up data or patterns that are not present
 - Keep your analysis concise but thorough
 - Use Indonesian Rupiah (Rp) when mentioning amounts
-- Format your response in plain text with clear section headings
+- Respond in English regardless of the language used in the data
+- Format your response in well-structured Markdown with clear headings, bullet points, and emphasis
 
 Do NOT:
 - Make up data you cannot see

--- a/prospectus_lumos/apps/documents/templatetags/formatting.py
+++ b/prospectus_lumos/apps/documents/templatetags/formatting.py
@@ -37,3 +37,14 @@ def idr(value: Any) -> str:
     Example: {{ 1234567|idr }} -> "Rp1.234.567"
     """
     return f"Rp{intdot(value)}"
+
+
+@register.filter(name="markdownify")
+def markdownify(value: str) -> str:
+    """Render Markdown text as HTML.
+
+    Example: {{ insights|markdownify|safe }}
+    """
+    import markdown
+
+    return markdown.markdown(value or "", extensions=["extra", "sane_lists"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ google-api-python-client==2.117.0
 
 # AI analysis
 google-generativeai==0.8.5
+markdown>=3.7

--- a/static_files/css/theme.css
+++ b/static_files/css/theme.css
@@ -207,6 +207,92 @@ body {
   color: var(--muted-text) !important;
 }
 
+/* AI insights markdown rendering */
+.ai-insights {
+  line-height: 1.75;
+  color: var(--text-color);
+}
+
+.ai-insights h1,
+.ai-insights h2,
+.ai-insights h3,
+.ai-insights h4 {
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.ai-insights h2 {
+  font-size: 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.35rem;
+}
+
+.ai-insights h3 {
+  font-size: 1.1rem;
+}
+
+.ai-insights p {
+  margin-bottom: 0.75rem;
+}
+
+.ai-insights ul,
+.ai-insights ol {
+  margin-bottom: 0.75rem;
+  padding-left: 1.5rem;
+}
+
+.ai-insights li {
+  margin-bottom: 0.25rem;
+}
+
+.ai-insights strong {
+  font-weight: 600;
+}
+
+.ai-insights em {
+  font-style: italic;
+}
+
+.ai-insights code {
+  background-color: var(--sidebar-bg);
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.25rem;
+  font-size: 0.875em;
+  border: 1px solid var(--border-color);
+}
+
+.ai-insights blockquote {
+  border-left: 3px solid var(--primary-color);
+  padding-left: 1rem;
+  margin-left: 0;
+  color: var(--muted-text);
+}
+
+.ai-insights table {
+  width: 100%;
+  margin-bottom: 1rem;
+  border-collapse: collapse;
+}
+
+.ai-insights th,
+.ai-insights td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color);
+  text-align: left;
+}
+
+.ai-insights th {
+  background-color: var(--sidebar-bg);
+  font-weight: 600;
+}
+
+.ai-insights hr {
+  border: none;
+  border-top: 1px solid var(--border-color);
+  margin: 1rem 0;
+}
+
 /* Loading indicator overlay */
 .loading-overlay {
   display: none;

--- a/templates/ai_analysis/expense.html
+++ b/templates/ai_analysis/expense.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load formatting %}
 
 {% block title %}AI Expense Analyzer - Prospectus Lumos{% endblock %}
 
@@ -71,8 +72,8 @@
         <h5 class="mb-0"><i class="bi bi-robot me-2"></i>AI Insights{{ filter_text }}</h5>
     </div>
     <div class="card-body">
-        <div class="ai-insights" style="white-space: pre-wrap; line-height: 1.7;">
-            {{ insights }}
+        <div class="ai-insights">
+            {{ insights|markdownify|safe }}
         </div>
     </div>
 </div>

--- a/templates/ai_analysis/income.html
+++ b/templates/ai_analysis/income.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load formatting %}
 
 {% block title %}AI Income Analyzer - Prospectus Lumos{% endblock %}
 
@@ -71,8 +72,8 @@
         <h5 class="mb-0"><i class="bi bi-robot me-2"></i>AI Insights{{ filter_text }}</h5>
     </div>
     <div class="card-body">
-        <div class="ai-insights" style="white-space: pre-wrap; line-height: 1.7;">
-            {{ insights }}
+        <div class="ai-insights">
+            {{ insights|markdownify|safe }}
         </div>
     </div>
 </div>

--- a/templates/ai_analysis/portfolio.html
+++ b/templates/ai_analysis/portfolio.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load formatting %}
 
 {% block title %}AI Portfolio Analyzer - Prospectus Lumos{% endblock %}
 
@@ -71,8 +72,8 @@
         <h5 class="mb-0"><i class="bi bi-robot me-2"></i>AI Insights{{ filter_text }}</h5>
     </div>
     <div class="card-body">
-        <div class="ai-insights" style="white-space: pre-wrap; line-height: 1.7;">
-            {{ insights }}
+        <div class="ai-insights">
+            {{ insights|markdownify|safe }}
         </div>
     </div>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -86,18 +86,6 @@
                         <i class="bi bi-robot me-2"></i>
                         AI Settings
                     </a>
-                    <a class="nav-link {% if selected_tab == 'ai_income' %}active{% endif %}" href="{% url 'ai_income_analyzer' %}">
-                        <i class="bi bi-cash-stack me-2"></i>
-                        AI Income
-                    </a>
-                    <a class="nav-link {% if selected_tab == 'ai_expenses' %}active{% endif %}" href="{% url 'ai_expense_analyzer' %}">
-                        <i class="bi bi-credit-card me-2"></i>
-                        AI Expenses
-                    </a>
-                    <a class="nav-link {% if selected_tab == 'ai_portfolio' %}active{% endif %}" href="{% url 'ai_portfolio_analyzer' %}">
-                        <i class="bi bi-pie-chart me-2"></i>
-                        AI Portfolio
-                    </a>
                 </nav>
             </div>
 

--- a/templates/expenses/expense_analyzer.html
+++ b/templates/expenses/expense_analyzer.html
@@ -6,6 +6,9 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Expense Analyzer</h1>
+    <a href="{% url 'ai_expense_analyzer' %}" class="btn btn-outline-primary">
+        <i class="bi bi-robot me-1"></i> AI Insight
+    </a>
 </div>
 
 <!-- Filters -->

--- a/templates/expenses/income_analyzer.html
+++ b/templates/expenses/income_analyzer.html
@@ -6,6 +6,9 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Income Analyzer</h1>
+    <a href="{% url 'ai_income_analyzer' %}" class="btn btn-outline-primary">
+        <i class="bi bi-robot me-1"></i> AI Insight
+    </a>
 </div>
 
 <!-- Filters -->

--- a/templates/expenses/portfolio_analyzer.html
+++ b/templates/expenses/portfolio_analyzer.html
@@ -9,6 +9,9 @@
         <h1 class="mb-0">Portfolio Analyzer</h1>
         <small class="text-muted">See how income, expenses, and savings work together over time.</small>
     </div>
+    <a href="{% url 'ai_portfolio_analyzer' %}" class="btn btn-outline-primary">
+        <i class="bi bi-robot me-1"></i> AI Insight
+    </a>
 </div>
 
 <!-- Filters -->


### PR DESCRIPTION
## Summary

- AI insight responses are now rendered as formatted HTML (Markdown → HTML) with proper CSS styling
- AI system prompt updated to respond in English and use Markdown formatting
- Removed AI Income, AI Expenses, AI Portfolio entries from the sidebar (AI Settings remains)
- Added "AI Insight" navigation buttons on Income, Expense, and Portfolio analyzer pages

## Changes

| File | Change |
|------|--------|
| `services.py` | Added English + Markdown instructions to Gemini system prompt |
| `formatting.py` | Added `markdownify` template filter |
| `theme.css` | Added comprehensive `.ai-insights` styling (headings, lists, tables, code, blockquotes) |
| `base.html` | Removed AI Income/AI Expenses/AI Portfolio from sidebar |
| `ai_analysis/*.html` | Switch insights rendering from raw text to `markdownify\|safe` |
| `expenses/*_analyzer.html` | Added AI Insight navigation buttons |

## Screenshots

N/A (no design review needed — standard Bootstrap buttons and existing card patterns)

## Checklist

- [x] Code compiles / no syntax errors
- [x] Linter passes (ruff format + ruff check)
- [x] Type checking passes (mypy)
- [x] Tests pass (15/16 — single pre-existing Django/Python 3.14 compat failure)
- [x] No new dependencies beyond `markdown` (already in project environment)

---

Closes APE-15
