### PR TITLE
fix(APE-17): Add pre-computed summary totals to AI analysis to prevent inaccurate LLM arithmetic

### DIFF
--- a/prospectus_lumos/apps/ai_analysis/services.py
+++ b/prospectus_lumos/apps/ai_analysis/services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+from decimal import Decimal
 from typing import Any
 
 import google.generativeai as genai
@@ -11,7 +12,14 @@ SYSTEM_PROMPT = """You are a financial analyst assistant for a personal finance 
 The user tracks their income and expenses monthly in Indonesian Rupiah (IDR).
 
 Your task is to analyze the provided financial data and deliver clear, honest, and helpful insights.
-The data will be provided in CSV format with columns: description, amount, category, transaction_type, year, month.
+The data includes a pre-computed SUMMARY section with accurate totals computed by the application,
+followed by the raw transaction records in CSV format.
+
+**CRITICAL**: When reporting total amounts (total expenses, total income, category subtotals, etc.),
+always use the **pre-computed values from the SUMMARY section**. Do NOT attempt to sum the raw
+transaction rows yourself — the totals in the summary are guaranteed to be accurate.
+
+The raw CSV columns are: description, amount, category, transaction_type, year, month.
 
 You MUST:
 - Explain noticeable trends (increasing spending in certain categories, income growth, etc.)
@@ -26,6 +34,7 @@ You MUST:
 
 Do NOT:
 - Make up data you cannot see
+- Calculate your own totals — always reference the SUMMARY section for aggregate numbers
 - Give financial advice that requires licensing
 - Share overly generic insights that could apply to anyone
 """
@@ -50,17 +59,74 @@ def get_ai_insights(api_token: str, model: str, data_text: str) -> str:
     return response.text or ""
 
 
+def _build_summary_lines(documents: Any, analyzer_type: str) -> list[str]:
+    """Build pre-computed summary lines that the AI can safely reference.
+
+    Returns a list of summary lines (one per line) to be prepended to the raw CSV data.
+    """
+    lines: list[str] = []
+
+    transaction_type_filter: str | None = None
+    if analyzer_type == "income":
+        transaction_type_filter = "income"
+    elif analyzer_type == "expense":
+        transaction_type_filter = "expense"
+
+    total_amount = Decimal("0")
+    category_totals: dict[str, Decimal] = {}
+    transaction_count = 0
+    months_covered: set[str] = set()
+
+    for doc in documents:
+        transactions = doc.transactions.all()
+        if transaction_type_filter:
+            transactions = transactions.filter(transaction_type=transaction_type_filter)
+
+        for tx in transactions:
+            amount = tx.amount if isinstance(tx.amount, Decimal) else Decimal(str(tx.amount))
+            total_amount += amount
+            transaction_count += 1
+            cat = tx.category or "Uncategorized"
+            category_totals[cat] = category_totals.get(cat, Decimal("0")) + amount
+            months_covered.add(f"{doc.year}-{doc.month:02d}")
+
+    total_formatted = f"Rp {total_amount:,.0f}"
+    lines.append("=== PRE-COMPUTED SUMMARY (accurate, use these values) ===")
+    lines.append(f"Analyzer type: {analyzer_type}")
+    lines.append(f"Total amount: {total_formatted}")
+    lines.append(f"Transaction count: {transaction_count}")
+    lines.append(f"Documents (months) covered: {len(months_covered)}")
+
+    if category_totals:
+        lines.append("Category subtotals:")
+        sorted_categories = sorted(category_totals.items(), key=lambda x: x[1], reverse=True)
+        for cat, subtotal in sorted_categories:
+            share_pct = (subtotal / total_amount * 100) if total_amount > 0 else Decimal("0")
+            lines.append(f"  - {cat}: Rp {subtotal:,.0f} ({share_pct:.1f}%)")
+
+    lines.append("=== END SUMMARY ===\n")
+    return lines
+
+
 def prepare_data_as_text(documents: Any, analyzer_type: str) -> str:
     """Convert document queryset into a CSV text format suitable for AI analysis.
+
+    Includes a pre-computed SUMMARY section with accurate totals so the AI
+    does not try to perform arithmetic on raw rows (which LLMs are unreliable at).
 
     Args:
         documents: A queryset or list of Document objects with prefetched transactions.
         analyzer_type: One of 'income', 'expense', 'portfolio'.
 
     Returns:
-        CSV-formatted text string.
+        Text string with pre-computed summary followed by CSV data.
     """
+    summary_lines = _build_summary_lines(documents, analyzer_type)
+
     output = io.StringIO()
+    for line in summary_lines:
+        output.write(line + "\n")
+
     writer = csv.writer(output)
     writer.writerow(["description", "amount", "category", "transaction_type", "year", "month"])
 

--- a/tests/test_ai_analysis.py
+++ b/tests/test_ai_analysis.py
@@ -200,6 +200,111 @@ class PrepareDataAsTextTests(TestCase):
         self.assertIn("Food", text)
         self.assertNotIn("Salary", text)
 
+    def test_prepare_data_summary_includes_accurate_totals(self) -> None:
+        doc = Document.objects.create(
+            user=self.user,
+            source=self.source,
+            month=6,
+            year=2025,
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="expense",
+            date="2025-06-01",
+            amount=100000,
+            description="Groceries",
+            category="Food",
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="expense",
+            date="2025-06-15",
+            amount=250000,
+            description="Electricity",
+            category="Utilities",
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="income",
+            date="2025-06-15",
+            amount=5000000,
+            description="Salary",
+            category="Paycheck",
+        )
+
+        text = prepare_data_as_text([doc], "expense")
+        self.assertIn("=== PRE-COMPUTED SUMMARY", text)
+        self.assertIn("Total amount: Rp 350,000", text)
+        self.assertIn("Category subtotals:", text)
+        self.assertIn("Utilities: Rp 250,000 (71.4%)", text)
+        self.assertIn("Food: Rp 100,000 (28.6%)", text)
+        self.assertIn("=== END SUMMARY ===", text)
+
+    def test_prepare_data_summary_income(self) -> None:
+        doc = Document.objects.create(
+            user=self.user,
+            source=self.source,
+            month=6,
+            year=2025,
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="income",
+            date="2025-06-15",
+            amount=5000000,
+            description="Salary",
+            category="Paycheck",
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="income",
+            date="2025-06-20",
+            amount=1500000,
+            description="Freelance",
+            category="Side Income",
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="expense",
+            date="2025-06-01",
+            amount=100000,
+            description="Groceries",
+            category="Food",
+        )
+
+        text = prepare_data_as_text([doc], "income")
+        self.assertIn("Total amount: Rp 6,500,000", text)
+        self.assertIn("Paycheck: Rp 5,000,000 (76.9%)", text)
+        self.assertIn("Side Income: Rp 1,500,000 (23.1%)", text)
+
+    def test_prepare_data_summary_portfolio(self) -> None:
+        doc = Document.objects.create(
+            user=self.user,
+            source=self.source,
+            month=6,
+            year=2025,
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="income",
+            date="2025-06-15",
+            amount=5000000,
+            description="Salary",
+            category="Paycheck",
+        )
+        Transaction.objects.create(
+            document=doc,
+            transaction_type="expense",
+            date="2025-06-01",
+            amount=100000,
+            description="Groceries",
+            category="Food",
+        )
+
+        text = prepare_data_as_text([doc], "portfolio")
+        self.assertIn("Total amount: Rp 5,100,000", text)
+        self.assertIn("Transaction count: 2", text)
+
     def test_prepare_portfolio_data_as_text(self) -> None:
         doc = Document.objects.create(
             user=self.user,


### PR DESCRIPTION
## Summary

Fix AI insight reporting inaccurate expense/income totals. The root cause was that `prepare_data_as_text` sent raw CSV transaction data to Gemini without pre-computed totals. Since LLMs are unreliable at arithmetic, Gemini would hallucinate incorrect totals (e.g. reporting Rp 52,987,700 when the actual total was Rp 185,554,973).

## What changed

- Added `_build_summary_lines` helper that computes accurate totals, category subtotals, and percentages from transaction data
- Modified `prepare_data_as_text` to prepend a clearly marked "PRE-COMPUTED SUMMARY" section before the raw CSV
- Updated `SYSTEM_PROMPT` to instruct the AI to always reference the pre-computed values instead of calculating its own
- Added 3 new tests verifying summary accuracy for expense, income, and portfolio analyzer types

## Testing

- All 19 existing tests pass
- 3 new tests added for summary verification
- `ruff check` and `ruff format` pass
- `mypy` passes on the changed service file

---

Closes APE-17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-computed summary output for AI analysis, including totals, transaction count, month coverage, and category breakdowns.
  * Summary values now appear before transaction rows in the generated text used for analysis.

* **Bug Fixes**
  * Ensured reported totals and category subtotals are taken from calculated summary data instead of being recomputed from raw rows, improving consistency.

* **Tests**
  * Added coverage for summary generation across expense, income, and portfolio modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->